### PR TITLE
fix: ICP/lead scores always 1-100 (floor 1)

### DIFF
--- a/.claude/commands/gtm/validate-list.md
+++ b/.claude/commands/gtm/validate-list.md
@@ -78,8 +78,8 @@ Before scoring, check whether company-level fields are populated (industry, empl
 
 **Pass 1 — Company scoring:**
 6a. Group records by company domain
-6b. For each unique company, calculate `company_score` (0-100) using the account scoring model in lead-scoring.md
-6c. Assign company tier: A (80-100), B (60-79), C (40-59), D (20-39), F (0-19)
+6b. For each unique company, calculate `company_score` (1-100, floor 1 — see lead-scoring.md "Score range") using the account scoring model in lead-scoring.md
+6c. Assign company tier: A (80-100), B (60-79), C (40-59), D (20-39), F (1-19)
 6d. Remove all contacts at F-tier companies (company_score < 20) — log removal count, not names
 6e. Flag D-tier companies with `review_flag: company-d-tier` — hold unless user overrides
 6f. Display company scoring summary:
@@ -91,19 +91,19 @@ Before scoring, check whether company-level fields are populated (industry, empl
 
 **Pass 2 — Prospect scoring (A/B-tier companies only):**
 7. Score every remaining contact using the rubric in RULES.md (0-3 ICP score)
-8. Calculate prospect score (0-100) using lead-scoring.md — company fit component uses `company_score × 0.30` instead of re-scoring firmographics
+8. Calculate prospect score (1-100, floor 1) using lead-scoring.md — company fit component uses `company_score × 0.30` instead of re-scoring firmographics
    - Apply ICP ceiling rule: icp_score 2 → max 79, icp_score 1 → max 59
    - Check RULES.md for `## Lead scoring overrides` — apply any custom weights
-9. Assign prospect tier: A (80-100), B (60-79), C (40-59), D (20-39), F (0-19)
+9. Assign prospect tier: A (80-100), B (60-79), C (40-59), D (20-39), F (1-19)
 10. Add columns: `company_score`, `company_tier`, `icp_score`, `lead_score`, `score_tier`, `rejection_reason`, `review_flag`
 
 ### If scoring mode = people-first
 
 6. Score every cleaned record using the rubric in RULES.md (0-3 ICP score)
-7. Calculate weighted lead score (0-100) using lead-scoring.md (original 5-component model)
+7. Calculate weighted lead score (1-100, floor 1) using lead-scoring.md (original 5-component model)
    - Check workspace RULES.md for `## Lead scoring overrides` — apply any custom weights
    - If no overrides, use default weights
-8. Assign score tier: A (80-100), B (60-79), C (40-59), D (20-39), F (0-19)
+8. Assign score tier: A (80-100), B (60-79), C (40-59), D (20-39), F (1-19)
 9. Add columns: icp_score, lead_score, score_tier, rejection_reason, review_flag
 10. Add columns (same as company-first — proceed to shared steps)
 

--- a/.claude/gtmos/references/csv-format.md
+++ b/.claude/gtmos/references/csv-format.md
@@ -41,7 +41,7 @@ All lists in GTMOS follow this standard format. When importing from external too
 | Column | Type | Description | Values |
 |--------|------|-------------|--------|
 | `icp_score` | integer | ICP fit score | `0-3` |
-| `lead_score` | float | Weighted lead score | `0-100` |
+| `lead_score` | float | Weighted lead score (floor 1) | `1-100` |
 | `rejection_reason` | string | Why rejected (if score 0) | `Personal email domain` |
 | `review_flag` | string | Flag for manual review | `catch-all email` |
 

--- a/.claude/gtmos/references/defaults.md
+++ b/.claude/gtmos/references/defaults.md
@@ -111,7 +111,8 @@ For `/gtm:provision` (see infrastructure-provisioning.md).
 | ICP ceiling — icp_score 2 | Max prospect score: 79 | Non-overridable |
 | ICP ceiling — icp_score 1 | Max prospect score: 59 | Non-overridable |
 | Hot tier threshold | 80+ | RULES.md |
-| Reject tier threshold | 0-19 | RULES.md |
+| Reject tier threshold | 1-19 | RULES.md |
+| Score range (company + contact) | 1-100, floor 1 (never 0) | Non-overridable |
 
 ## Enrichment defaults
 

--- a/.claude/gtmos/references/lead-scoring.md
+++ b/.claude/gtmos/references/lead-scoring.md
@@ -5,12 +5,12 @@ GTM:OS uses a **two-layer scoring model**: account score first, prospect score s
 ## Two-layer model
 
 ```
-Layer 1: Account score (0-100)
+Layer 1: Account score (1-100)
   → Score companies before researching people
   → Only proceed to Layer 2 for A/B-tier accounts (score ≥ 60)
   → F-tier accounts (< 20) are removed entirely
 
-Layer 2: Prospect score (0-100)
+Layer 2: Prospect score (1-100)
   → Score individual contacts within approved accounts
   → Company fit component uses company_score directly (no re-scoring company)
   → Prospect score determines personalization depth and enrichment priority
@@ -24,9 +24,16 @@ Scoring mode: people-first  ← legacy, scores contacts directly without account
 
 When `people-first` is set, skip account scoring entirely and use the original 5-component model below.
 
+## Score range — always 1-100
+
+Both the account/company score and the prospect/contact score are reported on a **1-100 scale — never 0**:
+- The minimum any scored record receives is **1**. If the weighted components sum to less than 1, clamp the score up to 1.
+- A record that fails ICP qualification (icp_score 0 / outside ICP) is **rejected and not scored at all** — it gets a `rejection_reason`, not a score of 0. So 0 never appears as a score.
+- This applies to **both contacts and companies**. Individual component sub-scores below may still contribute 0 points (e.g. "industry not listed = 0"), but the rolled-up `company_score` and `lead_score`/`prospect_score` are always 1-100.
+
 ---
 
-## Account scoring (0-100)
+## Account scoring (1-100)
 
 Score companies before prospecting into them. Produces `company_score` column in lists.
 
@@ -93,7 +100,7 @@ Cap: 30 points. Signals stack up to the cap.
 | B — Active | 60-79 | Standard enrichment, find 1-2 contacts |
 | C — Monitor | 40-59 | Light enrichment only, hold until better signal |
 | D — Deprioritise | 20-39 | Do not enrich — revisit if signal improves |
-| F — Remove | 0-19 | Remove from list entirely |
+| F — Remove | 1-19 | Remove from list entirely |
 
 **Credit gate:** enrichment only runs on A/B-tier accounts. C-tier and below are held until they move up.
 
@@ -251,14 +258,14 @@ Score based on prior interaction (only applies to re-engagement or multi-campaig
 | B — Warm | 60-79 | Standard sequence, good personalization, include in A/B tests |
 | C — Cool | 40-59 | Standard sequence, template personalization, batch send |
 | D — Cold | 20-39 | Lower priority, consider holding for better signal or re-engagement later |
-| F — Reject | 0-19 | Do not ship — remove from list or flag for manual review |
+| F — Reject | 1-19 | Do not ship — remove from list or flag for manual review |
 
 ---
 
 ## How to use
 
 1. During `/gtm:validate-list`, calculate lead_score for each contact
-2. The basic `icp_score` (0-3) maps roughly: 3=A/B, 2=B/C, 1=C/D, 0=F
+2. The basic `icp_score` (0-3) maps roughly: 3=A/B, 2=B/C, 1=C/D, 0 = rejected (not scored)
 3. Lead score adds granularity within each ICP tier
 4. Sort shipped lists by lead_score descending — best leads get outreach first
 5. Use score tiers to decide personalization depth:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Changed
+- **ICP / lead scores are now always 1-100** (floor 1, never 0) for both companies (`company_score`) and contacts (`lead_score` / `prospect_score`). A record that would compute below 1 is clamped to 1; records that fail ICP qualification (icp_score 0 / outside ICP) are rejected with a `rejection_reason`, not scored 0. F tier is now 1-19. Component sub-scores may still contribute 0 individually, but the rolled-up total is always 1-100. (`lead-scoring.md`, `validate-list.md`, `defaults.md`, `csv-format.md`.)
+
 ## [1.6.0] — 2026-06-16
 
 ### Added

--- a/GTMOS.md
+++ b/GTMOS.md
@@ -534,7 +534,7 @@ After every enrichment run, update hit rate tracking in TOOLS.md so the waterfal
 
 - Apply ICP filters strictly. When in doubt, reject.
 - Score every record 0-3 using the rubric in RULES.md
-- Calculate weighted lead score (0-100) using `.claude/gtmos/references/lead-scoring.md` — check workspace RULES.md for overrides
+- Calculate weighted lead score (1-100, floor 1) using `.claude/gtmos/references/lead-scoring.md` — check workspace RULES.md for overrides
 - Use the standard CSV format from `.claude/gtmos/references/csv-format.md` for all list imports and exports
 - Explain rejections — say why, not just that it was rejected
 - Output a validated CSV with added columns: icp_score, lead_score, rejection_reason, review_flag

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ If it drifts from the brief, it doesn't ship.
 
 **2. Research** → `/gtm:research` maps ICP companies, market landscape, and buying signals using Exa, Firecrawl, Ocean.io, and DiscoLike.
 
-**3. Build a list** → `/gtm:list-brief` creates a sourcing brief, `/gtm:enrich` fills gaps via waterfall enrichment across Apollo, Icypeas, Prospeo, and more. `/gtm:validate-list` cleans, scores (0-100), and validates.
+**3. Build a list** → `/gtm:list-brief` creates a sourcing brief, `/gtm:enrich` fills gaps via waterfall enrichment across Apollo, Icypeas, Prospeo, and more. `/gtm:validate-list` cleans, scores (1-100), and validates.
 
 **4. Write copy** → `/gtm:write` drafts a sequence using cold email best practices — peer voice, observation-led openers, interest-based CTAs, angle rotation per touch. `/gtm:write-multilang` writes natively in 12 languages.
 
@@ -485,7 +485,7 @@ Set up, track, and resolve A/B tests on subject lines, openers, CTAs, body copy,
 `/gtm:spam-check` (and an automatic pass inside `/gtm:write` and `/gtm:validate-copy`) scans every subject, body, and closeout line against a comprehensive banlist — promotional and phishing wording, em dashes, ALL CAPS, and silence-based "I'll stop if you don't reply" closeouts — and proposes a plain-language rewrite for every flag. A failed scan blocks the launch check.
 
 ### List quality scorecard
-`/gtm:score-list` grades a list A+ to F across 8 list-level dimensions — email verification coverage, duplicate emails, domain concentration, title relevance, bad-title detection, catch-all density, ICP fit, and name quality. Runs inside `/gtm:validate-list` and gates shipping: a list below C-grade doesn't ship. Complements the per-contact 0-100 lead score.
+`/gtm:score-list` grades a list A+ to F across 8 list-level dimensions — email verification coverage, duplicate emails, domain concentration, title relevance, bad-title detection, catch-all density, ICP fit, and name quality. Runs inside `/gtm:validate-list` and gates shipping: a list below C-grade doesn't ship. Complements the per-contact 1-100 lead score.
 
 ### Positive reply scoring
 `/gtm:reply-score` computes the metric that actually matters: positive reply rate (positive replies / total sent), not raw reply rate. Classifies every reply, reports against benchmarks (≥1% good, ≥2% great), flags hostile/unsub risk, and surfaces the positive replies that need a human response now.
@@ -570,7 +570,7 @@ GTM:OS ships with sensible defaults for everything:
 
 - **Copy:** 2-4 word lowercase subjects, 75-word first touch, interest-based CTAs, banned spam words
 - **Sending:** 40 emails/inbox/day, 14-day warmup minimum, holiday blackouts for 20+ countries
-- **Scoring:** weighted 0-100 lead scoring (company fit, persona, signals, data quality, engagement)
+- **Scoring:** weighted 1-100 lead scoring, floor 1 (company fit, persona, signals, data quality, engagement)
 - **Compliance:** optional regulation toggles, suppression checks, unsubscribe on every email, bounce auto-removal
 
 **Every default is overridable per workspace.** Add a `## Lead scoring overrides` section to RULES.md, change copy rules in TOV.md, adjust sending limits in INFRASTRUCTURE.md. If you don't override, the defaults just work.
@@ -600,7 +600,7 @@ GTM:OS ships with sensible defaults for everything:
 | `/gtm:list-brief <ws> <campaign>` | Create a list building brief |
 | `/gtm:enrich <ws> <type> [file]` | Waterfall enrichment (email, phone, people, company) |
 | `/gtm:clean-list <ws> [file]` | Clean and normalize a raw list |
-| `/gtm:validate-list <ws> [file]` | Clean + score (0-100) + validate |
+| `/gtm:validate-list <ws> [file]` | Clean + score (1-100) + validate |
 | `/gtm:write <ws> [touches] [channel]` | Draft an outbound sequence |
 | `/gtm:write-multilang <ws> <lang>` | Write sequence in a non-English language |
 | `/gtm:templates` | Browse saved sequence templates |


### PR DESCRIPTION
Ensures ICP/lead scoring is always **1-100** (floor 1, never 0) for both **companies** (`company_score`) and **contacts** (`lead_score` / `prospect_score`).

- A score that would compute below 1 is clamped to 1.
- Records that fail ICP qualification (icp_score 0 / outside ICP) are **rejected with a reason**, not scored 0 — so 0 never appears as a score.
- F tier is now **1-19**. Individual component sub-scores may still be 0 (e.g. "industry not listed = 0"); only the rolled-up total is floored to 1.

Touches `lead-scoring.md`, `validate-list.md`, `defaults.md`, `csv-format.md`, and aligns prose in `README.md` / `GTMOS.md`. Tier ranges (80-100 etc.) and the historical changelog are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)