### PR TITLE
docs: update Crispy description (175 tools, current pricing)

### DIFF
--- a/.claude/gtmos/references/clay-ecosystem.md
+++ b/.claude/gtmos/references/clay-ecosystem.md
@@ -130,7 +130,7 @@ Source: clay.com/integrations
 
 | Tool | What it does | In GTM:OS? |
 |------|-------------|-----------|
-| **Crispy** | MCP server — Claude Code controls LinkedIn directly (78 tools) | Yes (not in Clay) |
+| **Crispy** | MCP server — Claude Code controls LinkedIn directly (175 tools) | Yes (not in Clay) |
 | **PhantomBuster** | LinkedIn automation, execution-time based | Partial — in pricing ref |
 
 ---

--- a/.claude/gtmos/references/tool-pricing.md
+++ b/.claude/gtmos/references/tool-pricing.md
@@ -163,16 +163,18 @@ Last updated: 2026-03
 ## LinkedIn Automation
 
 ### Crispy
-- **Model:** Per-seat subscription
-- **Paid plans:** Pro €19/mo/seat, Team €29/mo/seat, Agency €99/mo base + €29/mo/seat
-- **What it is:** LinkedIn MCP server — 78 tools that connect directly to Claude Code
+- **Model:** Per-seat subscription — one plan, everything included (no feature gates)
+- **Paid plans:** $49/seat/mo, or $39/seat/mo billed annually (14-day money-back guarantee)
+- **What it is:** "The LinkedIn API for AI agents" — MCP server with 175 tools that connect directly to Claude Code (also 28 curated REST endpoints)
 - **What's included:**
-  - Connection requests, messaging sequences, profile views
-  - Sales Navigator integration — search, filter, save leads, extract lists
+  - Outreach: connection requests, messaging, multi-step campaign sequences with auto follow-ups
+  - Inbox management; content drafting + scheduling (posts, comments, reactions)
+  - Search + Sales Navigator integration — filter, save leads, extract lists
+  - Network analytics + job-change detection
   - MCP architecture — Claude Code orchestrates LinkedIn actions via tool calls (no CSV export/import)
 - **Default limits:** 25 connections/day, 50 profile views/day (adjustable in dashboard)
 - **GTMOS unit:** LinkedIn action
-- **Typical cost:** €19/mo flat (Pro) — no per-action charges
+- **Typical cost:** $49/mo flat ($39 annual) — no per-action charges
 - **Note:** Because Crispy works as an MCP server, it's the only LinkedIn tool in this list that Claude Code can control directly. Other LinkedIn tools (PhantomBuster) require manual setup and CSV handling.
 
 ### PhantomBuster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here.
 
 ### Changed
 - **ICP / lead scores are now always 1-100** (floor 1, never 0) for both companies (`company_score`) and contacts (`lead_score` / `prospect_score`). A record that would compute below 1 is clamped to 1; records that fail ICP qualification (icp_score 0 / outside ICP) are rejected with a `rejection_reason`, not scored 0. F tier is now 1-19. Component sub-scores may still contribute 0 individually, but the rolled-up total is always 1-100. (`lead-scoring.md`, `validate-list.md`, `defaults.md`, `csv-format.md`.)
+- **Crispy description updated** to match crispy.sh — "the LinkedIn API for AI agents," **175 tools** (was 78), broader capabilities (outreach, inbox, content, analytics, search + Sales Navigator, multi-step campaigns), and current pricing **$49/seat/mo ($39 annual)** (replaces the stale tiered €-pricing). Across README, `GTMOS.md`, `tool-pricing.md`, and `clay-ecosystem.md`.
 
 ## [1.6.0] — 2026-06-16
 

--- a/GTMOS.md
+++ b/GTMOS.md
@@ -148,7 +148,7 @@ If the operator's message already names a workspace or campaign, skip the prompt
 **Tool scan logic:**
 
 1. **MCP servers** — check if these MCP tool prefixes are available in the current session:
-   - `crispy` → Crispy (LinkedIn — 78 tools)
+   - `crispy` → Crispy (LinkedIn — 175 tools)
    - `exa` → Exa (semantic search, company research)
    - `firecrawl` or `FIRECRAWL` → Firecrawl (web scraping, data extraction)
    - `slack` → Slack (notifications, alerts)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ That's it. GTM:OS boots automatically — shows the banner, scans your connected
 GTM:OS works with your existing tools. Two ways to connect:
 
 **MCP servers (recommended)** — Claude can use these tools directly with full capabilities:
-- [Crispy](https://crispy.sh?ref=gtmos) — LinkedIn automation (78 tools)
+- [Crispy](https://crispy.sh?ref=gtmos) — the LinkedIn API for AI agents: outreach, inbox, content, analytics, search + Sales Navigator (175 tools)
 - [Exa](https://exa.ai?ref=gtmos) — semantic web search and company research
 - [Firecrawl](https://firecrawl.dev?ref=gtmos) — web scraping and data extraction
 
@@ -384,7 +384,7 @@ GTM:OS connects to 70+ tools across the outbound stack. Use what you have — sk
 ### LinkedIn
 | Tool | What it does | Pricing |
 |------|-------------|---------|
-| **Crispy** | MCP server — Claude Code controls LinkedIn directly. Connection requests, messaging, Sales Navigator search + extract. 78 tools. | From EUR19/mo/seat |
+| **Crispy** | MCP server — "the LinkedIn API for AI agents." Claude Code drives LinkedIn end to end: outreach, inbox, content/posts, analytics, search + Sales Navigator, multi-step campaigns. 175 tools. | $49/seat/mo ($39 annual) |
 | **HeyReach** | LinkedIn outreach at scale — multiple accounts, agency mode, API | From $79/mo |
 | **PhantomBuster** | LinkedIn + web scraping automation — 100+ phantoms for any task | Free 2h/day, from $56/mo |
 


### PR DESCRIPTION
Updates the Crispy tool description to match **crispy.sh** (verified):

- **175 tools** (was 78)
- **"The LinkedIn API for AI agents"** — outreach, inbox, content/posts, analytics, search + Sales Navigator, multi-step campaigns (was just "LinkedIn automation")
- Pricing: current **$49/seat/mo ($39 annual)** single plan (replaces the stale tiered €19/€29/€99)

Across `README.md`, `GTMOS.md`, `tool-pricing.md`, `clay-ecosystem.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)