### PR TITLE
docs: update Crispy in TOOLS.md template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here.
 
 ### Changed
 - **ICP / lead scores are now always 1-100** (floor 1, never 0) for both companies (`company_score`) and contacts (`lead_score` / `prospect_score`). A record that would compute below 1 is clamped to 1; records that fail ICP qualification (icp_score 0 / outside ICP) are rejected with a `rejection_reason`, not scored 0. F tier is now 1-19. Component sub-scores may still contribute 0 individually, but the rolled-up total is always 1-100. (`lead-scoring.md`, `validate-list.md`, `defaults.md`, `csv-format.md`.)
-- **Crispy description updated** to match crispy.sh — "the LinkedIn API for AI agents," **175 tools** (was 78), broader capabilities (outreach, inbox, content, analytics, search + Sales Navigator, multi-step campaigns), and current pricing **$49/seat/mo ($39 annual)** (replaces the stale tiered €-pricing). Across README, `GTMOS.md`, `tool-pricing.md`, and `clay-ecosystem.md`.
+- **Crispy description updated** to match crispy.sh — "the LinkedIn API for AI agents," **175 tools** (was 78), broader capabilities (outreach, inbox, content, analytics, search + Sales Navigator, multi-step campaigns), and current pricing **$49/seat/mo ($39 annual)** (replaces the stale tiered €-pricing). Across README, `GTMOS.md`, `tool-pricing.md`, `clay-ecosystem.md`, and the `TOOLS.md` template.
 
 ## [1.6.0] — 2026-06-16
 

--- a/_template/TOOLS.md
+++ b/_template/TOOLS.md
@@ -154,7 +154,7 @@ For pricing details, see .claude/gtmos/references/tool-pricing.md
 - Push to Crispy: connection requests, LinkedIn messages, Sales Navigator searches
 - Pull from Crispy: connection acceptance rates, reply rates, reply content, Sales Navigator lead lists
 - Credit behaviour (writes): confirm-before-every-use
-- Notes: MCP server with 78 tools — connects directly to Claude Code. Includes Sales Navigator integration. No CSV exports needed — Claude Code can run LinkedIn actions via tool calls.
+- Notes: "The LinkedIn API for AI agents" — MCP server with 175 tools — connects directly to Claude Code. Outreach, inbox, content, analytics, search + Sales Navigator, multi-step campaigns. No CSV exports needed — Claude Code can run LinkedIn actions via tool calls.
 
 ### Attio
 - Status: active / inactive


### PR DESCRIPTION
Follow-up to #11 — the `_template/TOOLS.md` Crispy entry still said "78 tools." Now 175 tools + the broader capability description, matching the rest of the repo and crispy.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)